### PR TITLE
Add repo name for binder

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,9 +57,9 @@ jupyterhub_interact_text: Interact             # The text that interact buttons 
 use_binder_button: false                 # If 'true', add a binder button for interactive links
 binderhub_url: https://mybinder.org                        # The URL for your BinderHub. If no URL, use ""
 binder_repo_base: https://github.com/                     # The site on which the textbook repository is hosted
-binder_repo_org: YOUR-ORG                     # The username or organization that owns this repository
-binder_repo_name: YOUR-REPO                        # The name of the repository on the web
-binder_repo_branch: gh-pages                   # The branch on which your textbook is hosted.
+binder_repo_org: veerg24                     # The username or organization that owns this repository
+binder_repo_name: myonlinebook                        # The name of the repository on the web
+binder_repo_branch: main                 # The branch on which your textbook is hosted.
 binderhub_interact_text: Interact              # The text that interact buttons will contain.
 
 # Thebelab settings


### PR DESCRIPTION
Hi Veer,

 I think this change may be what is needed to get Binder to work with the doc.
 There is a setting in _config.yml for which org, repo and branch that Binder will use. 
 That is not set by default. For now I have set it to the book repo. 

Chris